### PR TITLE
Fixes some small errors and introduce test for PDS files

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -4,3 +4,10 @@ git-tree-sha1 = "08d3017c167477b4c13de8239cbe7ecee07a60c9"
     [[XGM2016.download]]
     sha256 = "00c9117447d18f365e4b8030e9312ca73eed0d07d11534e06fd95b900f49418c"
     url = "https://gist.github.com/andreapasquale94/8692fcaa1e61afd600d29d53b55b4d78/raw/08d3017c167477b4c13de8239cbe7ecee07a60c9.tar.gz"
+
+[JGL100K]
+git-tree-sha1 = "dad6db77e6d222bdc7836804868d3e25518fe163"
+
+    [[JGL100K.download]]
+    sha256 = "62c1114551fb4ba553b9d534d85833ecea754b52fdf94d6e4d11c53546b181af"
+    url = "https://gist.github.com/jackyarndley/2a890c30600a79e3f64ebbb4014ac741/raw/dad6db77e6d222bdc7836804868d3e25518fe163.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ julia = "1.8"
 [extras]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [targets]
-test = ["Test", "LinearAlgebra", "ForwardDiff", "StaticArrays"]
+test = ["Test", "ForwardDiff", "Pkg"]

--- a/src/Gravity/harmonics/type.jl
+++ b/src/Gravity/harmonics/type.jl
@@ -222,7 +222,7 @@ function parse_model(
         )
     end
 
-    if !(data.tide_system == :zero_tide)
+    if (typeof(data) == GravityHarmonicsICGEMData) && !(data.tide_system == :zero_tide)
         throw(
             NotImplementedError("tide system '$(d.tide_system)' not supported")
         )

--- a/src/Gravity/harmonics/type.jl
+++ b/src/Gravity/harmonics/type.jl
@@ -85,13 +85,13 @@ end
 function precompute_coefficients!(η0, η1, deg)
     # Zonal & tesseral terms 
     η0[1, 1] = 0  
-    @inbounds for n in 1:deg+1
+    @inbounds for n in 1:deg
         η0[n+1, 1] = (n-1)/n
         η0[n+1, n+1] = 2n-1
     end
 
     # Sectorial terms
-    @inbounds for n in 2:deg+1
+    @inbounds for n in 2:deg
         for m in 1:n-1 
             η0[n+1, m+1] = (2n-1)/(n-m)
             η1[n+1, m+1] = (n+m-1)/(n-m)

--- a/test/Gravity/harmonics.jl
+++ b/test/Gravity/harmonics.jl
@@ -110,8 +110,53 @@ end
     
     end
 
+end
+
+
+@testset "PDS based, static model" verbose=true begin 
+   
+    PATH_PDS = artifact"JGL100K" 
+    DATA_PDS = parse_data(
+        Float64, GravityHarmonicsPDSData, joinpath(PATH_PDS, "jgl100k1.sha"); 
+        maxdegree=51
+    )
+
+    @testset "Accelerations" verbose=true begin
     
-
-
-
+        @testset "zonal terms" verbose=true begin
+            degree = 10
+            mz = parse_model(Float64, GravityHarmonics, DATA_PDS, degree, true)
+        
+            for _ in 1:1000
+                pos = rand(3)
+                pos /= norm(pos)
+                radius = 1 
+                μ = 1 
+        
+                fd = ForwardDiff.gradient(x->compute_potential(mz, x, μ, radius), pos)
+                an = compute_acceleration(mz, pos, μ, radius)
+        
+                @test maximum(abs.(fd-an)) ≤ 1e-14
+            end
+        end    
+    
+        @testset "all terms" verbose=true begin
+            degree = 10
+            m = parse_model(Float64, GravityHarmonics, DATA_PDS, degree, false)
+        
+            for _ in 1:1000
+                pos = rand(3)
+                pos /= norm(pos)
+                radius = 1 
+                μ = 1 
+        
+                fd = ForwardDiff.gradient(x->compute_potential(m, x, μ, radius), pos)
+                an = compute_acceleration(m, pos, μ, radius)
+        
+                @test maximum(abs.(fd-an)) ≤ 1e-14
+            end
+        end
+    
+    end
+    
 end


### PR DESCRIPTION
This PR addresses some issues that came up when I was trying to use this package (Julia 1.10.2). 

- Out of bounds error in `precompute_coefficients!` : Called with `deg+1`, for loop increments from 2->`deg+1`, and inside the loop the `η0` and `η1` matrices are accessed 1 element out of bounds (maximum increment is +3 not +2). Reduced the loop increment by 1 to rectify this but could also be changed based on how the function is called. This could be a better alternative depending on what you intend.
- Fixed a bug where the `tide_system` is checked in the case of PDS data when it does not exist, and added another test (with a PDS artifact) that will validate the model on some PDS data from jgl100k1.sha lunar gravity model.